### PR TITLE
Allow disabling super filter, update output args

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,33 +134,34 @@ wsl
 
 
 ```
-Hierarchical feature engineering (HFE) for the reduction of features with respects to a factor or regressor
+'Hierarchical feature engineering (HFE) for the reduction of features with respects to a factor or regressor
+Usage:
+    taxaHFE.R [options] <METADATA> <DATA> <OUTPUT>
+    
+Options:
+    -h --help                         Show help text.
+    -v --version                      Show version.
+    -s --subject_identifier <string>  Metadata column name containing subject IDs [default: subject_id]
+    -l --label <string>               Metadata column name of interest for ML [default: cluster]
+    -t --feature_type <string>        Is the ML label a factor or numeric [default: factor]
+    -f --sample_fraction <float>      Only let rf see a fraction of total data [default: 1]
+    -a --abundance <float>            Feature abundance filter [default: 0.0001]
+    -p --prevalence <float>           Feature prevalence filter [default: 0.01]
+    -L --lowest_level <int>           Most general level allowed to compete [default: 2]
+    -m --max_depth <int>              How many hierarchical levels should be allowed to compete [default: 1000]
+    -c --cor_level <float>            Initial pearson correlation filter [default: 0.95]
+    -n --ncores <int>                 Number of cpu cores to use [default: 2]
+    -d --disable_super_filter         Disable running of the super filter (final forest competition)
+    -w --write_old_files              Write individual level files and old HFE files
+    -W --write_flattened_tree         Write a compressed backup of the entire competed tree
+    -D --write_both_outputs           Write an output for pre and post super filter results, overridden by --disable_super_filter
+    --nperm <int>                     Number of RF permutations [default: 40]
+    --seed <numeric>                  Set a random numeric seed, default is to use system time
 
-usage:    
-taxaHFE.R [options] <METADATA> <DATA> <OUTPUT>    
-
-Options:   
- -h --help  Show this screen.    
- -v --version  Show version.    
- -s --subject_identifier metadata column name containing subject IDs [default: subject_id]    
- -l --label metadata column name of interest for ML [default: cluster]    
- -t --feature_type is the ML label a factor or numeric [default: factor]    
- -f --sample_fraction only let rf see a fraction of total data [default: 1]    
- -a --abundance feature abundance filter [default: 0.0001]    
- -p --prevalence feature prevalence filter [default: 0.01]    
- -L --lowest_level most general level allowed to compete [default: 2]    
- -m --max_depth how many hierarchical levels should be allowed to compete [default: 1000]    
- -c --cor_level initial pearson correlation filter [default: 0.95]    
- -w --write_old_files write individual level files and old HFE files [default: TRUE]    
- -n --ncores number of cpu cores to use [default: 2]
- --nperm number of RF permutations [default: 40]
- --seed set a random seed, default is to use system time 
- 
- Arguments:    
- 
- METADATA path to metadata input (txt | tsv | csv)
- DATA path to input file from hierarchical data (i.e. hData data) (txt | tsv | csv)
- OUTPUT output file name (csv)
+Arguments:
+    METADATA path to metadata input (txt | tsv | csv)
+    DATA path to input file from hierarchical data (i.e. hData data) (txt | tsv | csv)
+    OUTPUT output file name (csv)
 ```
 
 --subject_identifier: this is a column that identifies the sample or subject ID in the input metadata. All subjectIDs should be unique. They will be coerced to unique values (and simplified snake_case alpha-numerics) using ```janitor::make_clean_names()```
@@ -188,6 +189,12 @@ Options:
 --nperm: number of RF permutations to make to average out the Gini impurity score. More permutations may decrease run to run variability in the number of features output, but at a cost of run time.
 
 --seed: the default behavior is to use ```Sys.time()``` to generate a random seed each time taxaHFE is run. If you set it to a number, it will likely return the same results across repeated runs (though this assumption has not been thoroughly tested).
+
+--disable_super_filter: if provided, will not run the final competition (super filter) against all the winning features
+
+--write_flattened_tree: if provided, will write a gzip backup of the entire flattened competed tree
+
+--write_both_outputs: if provided, will write the pre and post final competition (super filter) output files
 
 [METADATA]: A **full path** to the file that contains the metadata column you wish to predict with your hierarchical data. This file should contain BOTH your subject_identifier and your metadata label
 

--- a/run_taxaHFEv2.R
+++ b/run_taxaHFEv2.R
@@ -16,7 +16,6 @@
 setwd("/home/docker")
 
 ## load libraries =====================================================
-library(docopt)
 source("/home/docker/tree.R")
 # source("/scripts/utilities/tree.R")
 

--- a/run_taxaHFEv2.R
+++ b/run_taxaHFEv2.R
@@ -54,6 +54,9 @@ Arguments:
 
 # these options will be converted to numeric by load_docopt
 numeric_options <- c("sample_fraction", "abundance", "prevalence", "lowest_level", "max_depth", "cor_level", "ncores", "nperm")
+# to use this code line-by-line in the Rstudio context, commandArgs can be overloaded to specify the desired flags
+# ex. commandArgs <- function(x) { "-s Sample -l Category -L 3 example_inputs/metadata.txt example_inputs/microbiome_data.txt example_inputs/out.txt" }
+# these will be used by the options loader
 opt <- load_docopt(doc, version = 'taxaHFE.R v2.0\n\n', to_convert = numeric_options)
 
 ## Run main ====================================================================

--- a/run_taxaHFEv2.R
+++ b/run_taxaHFEv2.R
@@ -15,29 +15,37 @@
 ## set working dir to /home for the docker container
 setwd("/home/docker")
 
+## load libraries =====================================================
+library(docopt)
+source("/home/docker/tree.R")
+# source("/scripts/utilities/tree.R")
+
 ## add commandline options =====================================================
 
-library(docopt)
 'Hierarchical feature engineering (HFE) for the reduction of features with respects to a factor or regressor
 Usage:
     taxaHFE.R [options] <METADATA> <DATA> <OUTPUT>
     
 Options:
-    -h --help  Show this screen.
-    -v --version  Show version.
-    -s --subject_identifier metadata column name containing subject IDs [default: subject_id]
-    -l --label metadata column name of interest for ML [default: cluster]
-    -t --feature_type is the ML label a factor or numeric [default: factor]
-    -f --sample_fraction only let rf see a fraction of total data [default: 1]
-    -a --abundance feature abundance filter [default: 0.0001]
-    -p --prevalence feature prevalence filter [default: 0.01]
-    -L --lowest_level most general level allowed to compete [default: 2]
-    -m --max_depth how many hierarchical levels should be allowed to compete [default: 1000]
-    -c --cor_level initial pearson correlation filter [default: 0.95]
-    -w --write_old_files write individual level files and old HFE files [default: TRUE]
-    -n --ncores number of cpu cores to use [default: 2]
-    --nperm number of RF permutations [default: 40]
-    --seed set a random numeric seed, default is to use system time
+    -h --help                         Show help text.
+    -v --version                      Show version.
+    -s --subject_identifier <string>  Metadata column name containing subject IDs [default: subject_id]
+    -l --label <string>               Metadata column name of interest for ML [default: cluster]
+    -t --feature_type <string>        Is the ML label a factor or numeric [default: factor]
+    -f --sample_fraction <float>      Only let rf see a fraction of total data [default: 1]
+    -a --abundance <float>            Feature abundance filter [default: 0.0001]
+    -p --prevalence <float>           Feature prevalence filter [default: 0.01]
+    -L --lowest_level <int>           Most general level allowed to compete [default: 2]
+    -m --max_depth <int>              How many hierarchical levels should be allowed to compete [default: 1000]
+    -c --cor_level <float>            Initial pearson correlation filter [default: 0.95]
+    -n --ncores <int>                 Number of cpu cores to use [default: 2]
+    -d --disable_super_filter         Disable running of the super filter (final forest competition)
+    -w --write_old_files              Write individual level files and old HFE files
+    -W --write_flattened_tree         Write a compressed backup of the entire competed tree
+    -D --write_both_outputs           Write an output for pre and post super filter results, overridden by --disable_super_filter
+    --nperm <int>                     Number of RF permutations [default: 40]
+    --seed <numeric>                  Set a random numeric seed, default is to use system time
+
 Arguments:
     METADATA path to metadata input (txt | tsv | csv)
     DATA path to input file from hierarchical data (i.e. hData data) (txt | tsv | csv)
@@ -45,69 +53,14 @@ Arguments:
 
 ' -> doc
 
-opt <- docopt::docopt(doc, version = 
-                        'taxaHFE.R v2.0\n\n')
-
-## load functions ==============================================================
-
-source("/scripts/utilities/tree.R")
-#source("/home/docker/tree.R")
-
-## arg tests ===================================================================
-# opt <- data.frame(subject_identifier = character(),
-#                   label = character(),
-#                   feature_type = character(),
-#                   ncores = numeric(),
-#                   cor_level = numeric(),
-#                   sample_fraction = numeric(),
-#                   abundance = numeric(),
-#                   prevalence = numeric(),
-#                   write_old_files = character(),
-#                   lowest_level = numeric(),
-#                   max_depth = numeric(),
-#                   nperm = numeric(),
-#                   seed = numeric(),
-#                   METADATA = character(),
-#                   DATA = character(),
-#                   OUTPUT = character())
-# opt <- opt %>% tibble::add_row(
-#   subject_identifier = "Sample",
-#   label = "Category",
-#   feature_type = "factor",
-#   write_old_files = "TRUE",
-#   abundance = 0.0001,
-#   prevalence = 0.01,
-#   sample_fraction = 1,
-#   cor_level = 0.95,
-#   lowest_level = 3,
-#   max_depth = 1000,
-#   ncores = 4,
-#   nperm = 10,
-#   seed = 42,
-#   METADATA = "/home/docker/example_inputs/metadata.txt",
-#   DATA = "/home/docker/example_inputs/microbiome_data.txt",
-#   OUTPUT = "/home/docker/example_inputs/output.csv"
-# )
+# these options will be converted to numeric by load_docopt
+numeric_options <- c("sample_fraction", "abundance", "prevalence", "lowest_level", "max_depth", "cor_level", "ncores", "nperm")
+opt <- load_docopt(doc, version = 'taxaHFE.R v2.0\n\n', to_convert = numeric_options)
 
 ## Run main ====================================================================
 
 ## set random seed
-set_seed_func(seed = as.numeric(opt$seed))
-
-## check for inputs ============================================================
-cat("\n\n", "###########################\n", "Reading in data...\n", "###########################")
-
-## check and see if clean_files directory exists
-cat("\n\n","Checking for METADATA")
-if (file.exists(opt$METADATA)) {
-  cat("\n",paste0("Using ", opt$METADATA, " as input")) 
-} else { stop("Metadata input not found.") }
-
-## check for input file (hierarchical data)
-cat("\n","Checking for for input...")
-if (file.exists(opt$DATA)) {
-  cat("\n",paste0("Using ", opt$DATA, " as input")) 
-} else { stop("Input not found.") }
+set_seed_func(opt$seed)
 
 ## parameters specified
 cat("\n","Parameters specified: \n")
@@ -125,18 +78,15 @@ cat(paste0("--ncores: ", opt$ncores), "\n")
 cat(paste0("--nperm: ", opt$nperm), "\n")
 cat(paste0("OUTPUT: ", opt$OUTPUT))
 
-## read in metadata file =======================================================
+## check for inputs and read in read in =======================================================
+cat("\n\n", "###########################\n", "Reading in data...\n", "###########################")
 
-## rename the subject_identifier to subject_id and
-## rename the label to feature_of_interest
-## metadata, should be in tab or comma separated format
+## metadata file
 metadata <- read_in_metadata(input = opt$METADATA, 
                              subject_identifier = opt$subject_identifier, 
                              label = opt$label)
 
-## read in microbiome ==========================================================
-
-## read in data, should be in tab or comma separated format
+## (hierarchical) microbiome file ==========================================================
 hData <- read_in_microbiome(input = opt$DATA, 
                             meta = metadata, 
                             cores = opt$ncores)
@@ -145,86 +95,44 @@ hData <- read_in_microbiome(input = opt$DATA,
 cat("\n\n", "###########################\n", "Building Tree...\n", "###########################\n\n")
 cat("This may take a few minutes depending on how many features you have.\n")
 hTree <- build_tree(hData, 
-                    filter_prevalence = as.numeric(opt$prevalence), 
-                    filter_mean_abundance = as.numeric(opt$abundance))
+                    filter_prevalence = opt$prevalence,
+                    filter_mean_abundance = opt$abundance)
 
 ## Main competition ============================================================
-
 cat("\n", "###########################\n", "Competing Tree...\n", "###########################\n\n")
 
 competed_tree <- compete_tree(
   hTree,
   lowest_level = opt$lowest_level,
-  max_depth = as.numeric(opt$max_depth), # allows for all levels to be competed. Change to 1 for pairwise comparisons
+  max_depth = opt$max_depth, # allows for all levels to be competed. Change to 1 for pairwise comparisons
   col_names = colnames(hData)[2:NCOL(hData)],
   corr_threshold = opt$cor_level,
   metadata = metadata,
   ncores = opt$ncores,
   feature_type = opt$feature_type,
-  nperm = nperm,
+  nperm = opt$nperm,
   sample_fraction = calc_class_frequencies(
     input = metadata,
     feature_type = opt$feature_type,
     sample_fraction = opt$sample_fraction
   ),
+  disable_super_filter = opt$disable_super_filter
 )
 
 ## Extract information from tree  ==============================================
 # Flatten the tree and tree decisions
 cat("\n", "############################################\n", "Flattening tree and writing final output...\n", "############################################\n\n")
 
-col_names = colnames(hData)[2:NCOL(hData)]
-flattened_df <- flatten_tree_with_metadata(node = competed_tree)
-colnames(flattened_df)[11:NCOL(flattened_df)] <- col_names
-
-## filter to only winners
-flattened_noSF_winners <- flattened_df %>% 
-  dplyr::filter(., winner == TRUE)
-
-## clean names in case of duplicates
-flattened_noSF_winners$name <- janitor::make_clean_names(flattened_noSF_winners$name)
-
-## write noSF output
-output_nosf <- flattened_noSF_winners %>%
-  dplyr::select(., name, 11:dplyr::last_col()) %>%
-  tibble::remove_rownames() %>%
-  tibble::column_to_rownames(., var = "name") %>%
-  t() %>%
-  as.data.frame() %>%
-  tibble::rownames_to_column(var = "subject_id")
-
-output_nosf <- merge(metadata, output_nosf, by = "subject_id")
-readr::write_delim(file = paste0(tools::file_path_sans_ext(opt$OUTPUT), "_no_sf.csv"), x = output_nosf, delim = ",")
-
-## write SF output
-output_sf <- flattened_noSF_winners %>%
-  dplyr::filter(., sf_winner == TRUE) %>%
-  dplyr::select(., name, 11:dplyr::last_col()) %>%
-  tibble::remove_rownames() %>%
-  tibble::column_to_rownames(., var = "name") %>%
-  t() %>%
-  as.data.frame() %>%
-  tibble::rownames_to_column(var = "subject_id")
-
-output_sf <- merge(metadata, output_sf, by = "subject_id")
-readr::write_delim(file = opt$OUTPUT, x = output_sf, delim = ",")
-
-cat(" Features (no super filter): ", (ncol(output_nosf) - 2))
-cat("\n Features (super filter): ", (NCOL(output_sf) - 2), "\n")
-
-## write old files  ============================================================
-if (opt$write_old_files == TRUE) {
-  cat("\n", "###########################\n", "Writing old files...\n", "###########################\n\n")
-  
-  write_summary_files(input = flattened_df, metadata = metadata, output = opt$OUTPUT)
-  write_old_hfe(input = flattened_df, output = opt$OUTPUT)
-}
-
-## save flattened DF to come back to
-vroom::vroom_write(x = flattened_df, 
-                   file =  paste0(tools::file_path_sans_ext(opt$OUTPUT), "_raw_data.tsv.gz"), 
-                   num_threads = as.numeric(opt$ncores))
+generate_outputs(
+  competed_tree,
+  metadata,
+  colnames(hData)[2:NCOL(hData)],
+  opt$OUTPUT, opt$disable_super_filter,
+  opt$write_both_outputs,
+  opt$write_old_files,
+  opt$write_flattened_tree,
+  opt$ncores
+)
 
 ## message to user finish
 cat(" Outputs written! TaxaHFE completed. \n")
-

--- a/tree.R
+++ b/tree.R
@@ -840,6 +840,7 @@ load_docopt <- function(doc_string, version, to_convert) {
         if (is.na(numeric_option)) {
           stop(paste(option, "must be a numeric value"))
         }
+        return(numeric_option)
       }
       # otherwise return the value as before
       return(opt[[option]])

--- a/tree.R
+++ b/tree.R
@@ -835,7 +835,10 @@ load_docopt <- function(doc_string, version, to_convert) {
     function(option) {
       # if the option if in to_convert, return the converted value
       if (option %in% to_convert) { 
-        return(as.numeric(opt[[option]]))
+        numeric_option <- as.numeric(opt[[option]])
+        if (is.na(numeric_option)) {
+          stop(paste(option, "must be a numeric value"))
+        }
       }
       # otherwise return the value as before
       return(opt[[option]])

--- a/tree.R
+++ b/tree.R
@@ -15,17 +15,16 @@ library(vroom, quietly = T, verbose = F, warn.conflicts = F)
 library(tidyselect, quietly = T, verbose = F, warn.conflicts = F)
 
 
-## set random seed if desired
+## set random seed, defaults to system time
 set_seed_func <- function(seed) {
-  tryCatch(expr = set.seed(as.numeric(opt$seed)), 
-           error = function(e){
-             message('No random seed set. Using system time!') },
-           finally = function(f){
-             set.seed(as.numeric(Sys.time())) }
-  )
+  if (!is.null(seed)) {
+    set.seed(seed)
+  } else {
+    message('No random seed set. Using system time!')
+    set.seed(as.numeric(Sys.time()))
+  }
 }
 
-nperm <- as.numeric(opt$nperm) # permute the random forest this many times
 trim <- 0.02 # trim outliers from mean feature abundance calc
 
 ## helper functions ============================================================
@@ -37,8 +36,16 @@ trim <- 0.02 # trim outliers from mean feature abundance calc
 options(warn = -1)
 
 ## read in metadata  ===========================================================
+## rename the subject_identifier to subject_id and
+## rename the label to feature_of_interest
+## metadata, should be in tab or comma separated format
 read_in_metadata <- function(input, subject_identifier, label) {
-  
+  cat("\n\n", "Checking for METADATA")
+  if (file.exists(input) == FALSE) {
+    stop("METADATA input not found.")
+  }
+  cat("\n", paste0("Using ", input, " as METADATA"), "\n")
+
   # read extension to determine file delim
   if (strsplit(basename(input), split = "\\.")[[1]][2] %in% c("tsv","txt")) {
     delim = "\t"
@@ -60,8 +67,14 @@ read_in_metadata <- function(input, subject_identifier, label) {
 }
 
 ## read in microbiome data =====================================================
-read_in_microbiome <- function(input, meta = metadata, cores) {
-  
+## read in data, should be in tab or comma separated format
+read_in_microbiome <- function(input, metadata, cores) {
+  cat("\n", "Checking for DATA...")
+  if (file.exists(input) == FALSE) {
+    stop("DATA input not found.")
+  }
+  cat("\n", paste0("Using ", input, " as DATA"), "\n") 
+
   ## read extension to determine file delim
   if (strsplit(basename(input), split = "\\.")[[1]][2] %in% c("tsv","txt")) {
     delim = "\t"
@@ -73,7 +86,7 @@ read_in_microbiome <- function(input, meta = metadata, cores) {
   ## Useful for large datasets.
   hData <- suppressMessages(vroom::vroom(file = input, delim = delim, skip = 0, 
                                          .name_repair = "minimal", 
-                                         num_threads = as.numeric(cores)) %>% 
+                                         num_threads = cores) %>% 
                               dplyr::select(., -any_of(c("NCBI_tax_id", 
                                                          "clade_taxid"))) %>%
                               # clean names so they match metadata and remove
@@ -125,7 +138,7 @@ write_summary_files <- function(input, metadata, output) {
   levels <- c(1:max_levels)
   
   ## split raw data by pipe symbol into number of expected parts
-  count = 1
+  count <- 1
   for (i in seq(levels)) {
     if (i == 1) {
       next
@@ -155,7 +168,7 @@ write_summary_files <- function(input, metadata, output) {
     
     filename <- paste0("_level_", count, ".csv")
     readr::write_delim(x = file_merge, file = paste0(tools::file_path_sans_ext(output), filename), delim = ",")
-    count = count + 1
+    count <- count + 1
   }
   
 }
@@ -245,12 +258,12 @@ initial_leaf_values <- function(node, row_num, row_vector, filter_prevalence, fi
   node$abundance <- row_vector
   # indicates if the prevalence filter was passed
   node$passed_prevalence_filter <-
-    length(node$abundance[node$abundance != 0]) > (length(node$abundance) * as.numeric(filter_prevalence))
+    length(node$abundance[node$abundance != 0]) > (length(node$abundance) * filter_prevalence)
   # indicates if the mean abundance filter was passed
   node$passed_mean_abundance_filter <-
     mean(node$abundance, trim = trim) > filter_mean_abundance
   # defaults to be modified later
-  node$SF_winner <- FALSE
+  node$sf_winner <- FALSE
   node$winner <- FALSE
   node$highly_correlated <- FALSE
   node$lost_rf <- FALSE
@@ -536,10 +549,10 @@ compete_all_winners <- function(tree, metadata, col_names, sample_fraction, feat
   for (competitor in competitors) {
     if (competitor$id %in% rf_winners) {
       competitor$outcomes <- append(competitor$outcomes, sprintf("win: final rf winner, %s", outcome_str))
-      competitor$SF_winner <- TRUE
+      competitor$sf_winner <- TRUE
     } else {
       competitor$outcomes <- append(competitor$outcomes, sprintf("loss: final rf loser, %s", outcome_str))
-      competitor$SF_winner <- FALSE
+      competitor$sf_winner <- FALSE
     }
   }
 }
@@ -558,7 +571,8 @@ compete_all_winners <- function(tree, metadata, col_names, sample_fraction, feat
 # metadata: the metadata associated with the input df that generated the tree
 # sample_fraction: fraction of data to use in rf to help prevent data leakage
 # ncores: the number of cores to use when running the random forest
-compete_tree <- function(tree, modify_tree = TRUE, col_names, lowest_level = 2, max_depth = 1000, corr_threshold, metadata, sample_fraction, ncores, feature_type, nperm) {
+# disable_super_filter: disables running the final competition
+compete_tree <- function(tree, modify_tree = TRUE, col_names, lowest_level = 2, max_depth = 1000, corr_threshold, metadata, sample_fraction, ncores, feature_type, nperm, disable_super_filter) {
   # if not modifying the input tree, create a copy of the tree to perform the competition
   if (!modify_tree) tree <- data.tree::Clone(tree)
 
@@ -584,16 +598,20 @@ compete_tree <- function(tree, modify_tree = TRUE, col_names, lowest_level = 2, 
   
   # compete all winners
   # increasing nperm by a factor of 10 to further reduce the variability in the final rf importance scores
-  compete_all_winners(
-    tree,
-    metadata,
-    col_names = col_names,
-    sample_fraction = sample_fraction,
-    feature_type = feature_type,
-    nperm = nperm * 10,
-    ncores = ncores
-  )
-  
+  if (disable_super_filter == FALSE) {
+    compete_all_winners(
+      tree,
+      metadata,
+      col_names = col_names,
+      sample_fraction = sample_fraction,
+      feature_type = feature_type,
+      nperm = nperm * 10,
+      ncores = ncores
+    )
+  } else {
+    cat(" Skipping super filter\n")
+  }
+
   # return the tree
   return(tree)
 }
@@ -605,7 +623,7 @@ calculate_correlation <- function(df, corrThreshold) {
   return(
     suppressMessages(corrr::correlate(df)) %>%
       corrr::focus(., parentColumn) %>%
-      dplyr::filter(., .[[2]] >= as.numeric(corrThreshold)) %>%
+      dplyr::filter(., .[[2]] >= corrThreshold) %>%
       dplyr::pull(., term)
   )
 }
@@ -631,16 +649,16 @@ calc_class_frequencies <- function(input, feature_type, feature = "feature_of_in
     ## scores maybe its best to use all the data. Not ideal, but because
     ## sample sizes are usually a little small i think its better to use all
     ## data??
-    class_frequencies <- class_frequencies * as.numeric(sample_fraction)
+    class_frequencies <- class_frequencies * sample_fraction
     return(class_frequencies)
   } else {
-    return(as.numeric(sample_fraction))
+    return(sample_fraction)
   }
 }
 
 ## rf competition function =====================================================
 # TODO: document these inputs
-rf_competition <- function(df, metadata, parent_descendent_competition, feature_of_interest = "feature_of_interest", subject_identifier = "subject_id", feature_type = feature_type, sample_fraction = calc_class_frequencies(), ncores = ncores, nperm = nperm) {
+rf_competition <- function(df, metadata, parent_descendent_competition, feature_of_interest = "feature_of_interest", subject_identifier = "subject_id", feature_type, sample_fraction, ncores, nperm) {
   # merge node abundance + children abundance with metadata
   merged_data <- merge(df, metadata, by.x = "row.names", by.y = "subject_id")
   # clean node names so ranger doesnt throw an error
@@ -715,14 +733,13 @@ rf_competition <- function(df, metadata, parent_descendent_competition, feature_
 ## Flatten tree to data frame ==================================================
 ## exports tree as dataframe with tons of info on how the competition went
 flatten_tree_with_metadata <- function(node) {
-  
   df <- data.frame(
     name = node$name,
     depth = node$level,
     pathString = node$pathString,
     outcomes = paste(node$outcomes, collapse = "|\n"),
     winner = node$winner,
-    sf_winner = node$SF_winner,
+    sf_winner = node$sf_winner,
     rf_loss = node$lost_rf,
     highly_cor = node$highly_correlated,
     passed_prevelance = node$passed_prevalence_filter,
@@ -731,12 +748,99 @@ flatten_tree_with_metadata <- function(node) {
     stringsAsFactors = FALSE
   )
 
-  
-  
   if (length(node$children) > 0) {
     children_df <- do.call(rbind, lapply(node$children, flatten_tree_with_metadata))
     df <- rbind(df, children_df)
   }
   
   return(df)
+}
+
+# write an output file containing the HFE results
+write_output_file <- function(flattened_df, metadata, output_location, file_suffix) {
+  output_nosf <- flattened_df %>%
+    dplyr::select(., name, 11:dplyr::last_col()) %>%
+    tibble::remove_rownames() %>%
+    tibble::column_to_rownames(., var = "name") %>%
+    t() %>%
+    as.data.frame() %>%
+    tibble::rownames_to_column(var = "subject_id")
+
+  output_nosf <- merge(metadata, output_nosf, by = "subject_id")
+  readr::write_delim(file = paste0(tools::file_path_sans_ext(output_location), file_suffix), x = output_nosf, delim = ",")
+}
+
+# generate the outputs
+# if disable_super_filter is TRUE, the super filter competition wasn't run, and only one output will be generated
+# if both_outputs is FALSE, one file will be produced with the final level of competition that occurred
+generate_outputs <- function(tree, metadata, col_names, output_location, disable_super_filter, write_both_outputs, write_old_files, write_flattened_df_backup, ncores) {
+  # flatten tree back into metadata, and assign original column names from hData to the sample columns
+  flattened_df <- flatten_tree_with_metadata(tree)
+  colnames(flattened_df)[11:NCOL(flattened_df)] <- col_names
+
+  ## filter to only winners and clean names in case of duplicate
+  ## also further filtering for sf winners
+  flattened_winners <- flattened_df %>% 
+    dplyr::filter(., winner == TRUE)
+
+  flattened_winners$name <- janitor::make_clean_names(flattened_winners$name)
+
+  flattened_sf_winners <- flattened_winners %>%
+    dplyr::filter(., sf_winner == TRUE)
+
+  ## if super filter is disabled, write the flattened_winners as standard output
+  ## otherwise write the super filter winners as standard output
+  if (disable_super_filter == TRUE) {
+    write_output_file(flattened_winners, metadata, output_location, ".csv")
+  } else {
+    write_output_file(flattened_sf_winners, metadata, output_location, ".csv")
+  }
+
+  ## also write the non-sf output if both outputs are requested
+  if (write_both_outputs == TRUE && disable_super_filter == FALSE) {
+    write_output_file(flattened_winners, metadata, output_location, "_no_sf.csv")
+  }
+
+  cat(" Features (no super filter): ", (nrow(flattened_winners) - 2), "\n")
+  if (disable_super_filter != TRUE) {
+    cat("\n Features (super filter): ", (nrow(flattened_sf_winners) - 2), "\n")
+  }
+
+  ## write old files  ============================================================
+  if (write_old_files == TRUE) {
+    cat("\n", "###########################\n", "Writing old files...\n", "###########################\n\n")
+
+    write_summary_files(input = flattened_df, metadata = metadata, output = output_location)
+    write_old_hfe(input = flattened_df, output = output_location)
+  }
+
+  ## save flattened DF to come back to
+  if (write_flattened_df_backup == TRUE) {
+    vroom::vroom_write(x = flattened_df,
+                      file =  paste0(tools::file_path_sans_ext(output_location), "_raw_data.tsv.gz"),
+                      num_threads = ncores)
+  }
+}
+
+## loads docopt using the built in func and then converts the specified values to numeric
+## converts the docopt arguments to numeric if the opt name is in the provided vector
+## returns the updated docopt object
+## uses sapply to iterate of the names if the options, returning the converted value if found in to_convert
+## overloading commandArgs() to return an arbitrary string allows this to be run in rstudio
+load_docopt <- function(doc_string, version, to_convert) {
+  opt <- docopt::docopt(doc_string, commandArgs(TRUE), version = version)
+  
+  return(sapply(
+    names(opt), # names of the options
+    function(option) {
+      # if the option if in to_convert, return the converted value
+      if (option %in% to_convert) { 
+        return(as.numeric(opt[[option]]))
+      }
+      # otherwise return the value as before
+      return(opt[[option]])
+    },
+    # this ensure that sapply will keep the names
+    simplify = FALSE
+  ))
 }

--- a/tree.R
+++ b/tree.R
@@ -13,6 +13,7 @@ library(purrr, quietly = T, verbose = F, warn.conflicts = F)
 library(ranger, quietly = T, verbose = F, warn.conflicts = F)
 library(vroom, quietly = T, verbose = F, warn.conflicts = F)
 library(tidyselect, quietly = T, verbose = F, warn.conflicts = F)
+library(docopt, quietly = T, verbose = F, warn.conflicts = F)
 
 
 ## set random seed, defaults to system time


### PR DESCRIPTION
Overall goals here
- simplify `run_taxaHFEv2.R`
- add `disable_super_filter` capability
- set defaults for file outputs
- update flag handling

Changes
- Move input file existence check into `read_in_` functions
- Move output generation to tree.R as a function
- Add the following flags
  - `--disable_super_filter`: disables running of the final comp and does an output of the regular feature winners
  - `--write_flattened_tree`: write the flattened backup to gzip
  - `--write_both_outputs`: if super filter is run, right both outputs (regular comp winners and super filter winners)
- Changed  `--write_old_files` to be false by default
- Updated flag formatting, including indicating type of argument expected
- New docopt parsing function that converts specified flags to numeric type, returns error if option can't be converted
- commandArgs can be overloaded in Rstudio to use flag functions from there
- Remove numeric conversions from `tree.R` functions
- set_seed function does a null check now that the flag value is vetted
- lowercase `SF_winner` to `sf_winner`
- update README