### PR TITLE
Add in the ability to take in covariates

### DIFF
--- a/example_inputs/metadata.txt
+++ b/example_inputs/metadata.txt
@@ -1,290 +1,290 @@
-File	study	Sample	Category
-WF_40	UCI_Fiber_high	UCI_1	Industrialized
-WF_36	UCI_Fiber_low	UCI_2	Industrialized
-WF_38	UCI_Fiber_high	UCI_3	Industrialized
-WF_23	UCI_Fiber_high	UCI_4	Industrialized
-WF_34	UCI_Fiber_low	UCI_5	Industrialized
-WF_30	UCI_Fiber_high	UCI_6	Industrialized
-WF_28	UCI_Fiber_high	UCI_7	Industrialized
-WF_32	UCI_Fiber_high	UCI_8	Industrialized
-WF_6	UCI_Fiber_high	UCI_9	Industrialized
-WF_4	UCI_Fiber_high	UCI_10	Industrialized
-WF_16	UCI_Fiber_low	UCI_11	Industrialized
-WF_18	UCI_Fiber_low	UCI_12	Industrialized
-WF_14	UCI_Fiber_high	UCI_13	Industrialized
-WF_2	UCI_Fiber_low	UCI_14	Industrialized
-WF_10	UCI_Fiber_high	UCI_15	Industrialized
-WF_12	UCI_Fiber_high	UCI_16	Industrialized
-WF_81	UCI_Fiber_high	UCI_17	Industrialized
-WF_88	UCI_Fiber_low	UCI_18	Industrialized
-WF_82	UCI_Fiber_high	UCI_19	Industrialized
-WF_87	UCI_Fiber_low	UCI_20	Industrialized
-WF_84	UCI_Fiber_low	UCI_21	Industrialized
-WF_86	UCI_Fiber_high	UCI_22	Industrialized
-WF_83	UCI_Fiber_low	UCI_23	Industrialized
-WF_85	UCI_Fiber_high	UCI_24	Industrialized
-WF_80	UCI_Fiber_low	UCI_25	Industrialized
-WF_74	UCI_Fiber_high	UCI_26	Industrialized
-WF_79	UCI_Fiber_low	UCI_27	Industrialized
-WF_73	UCI_Fiber_high	UCI_28	Industrialized
-WF_76	UCI_Fiber_low	UCI_29	Industrialized
-WF_77	UCI_Fiber_high	UCI_30	Industrialized
-WF_75	UCI_Fiber_low	UCI_31	Industrialized
-WF_78	UCI_Fiber_high	UCI_32	Industrialized
-WF_69	UCI_Fiber_high	UCI_33	Industrialized
-WF_62	UCI_Fiber_low	UCI_34	Industrialized
-WF_66	UCI_Fiber_low	UCI_35	Industrialized
-WF_68	UCI_Fiber_high	UCI_36	Industrialized
-WF_67	UCI_Fiber_low	UCI_37	Industrialized
-WF_60	UCI_Fiber_high	UCI_38	Industrialized
-WF_59	UCI_Fiber_high	UCI_39	Industrialized
-WF_204	UCI_Fiber_low	UCI_40	Industrialized
-WF_203	UCI_Fiber_low	UCI_41	Industrialized
-WF_202	UCI_Fiber_high	UCI_42	Industrialized
-WF_58	UCI_Fiber_low	UCI_43	Industrialized
-WF_42	UCI_Fiber_high	UCI_44	Industrialized
-WF_52	UCI_Fiber_low	UCI_45	Industrialized
-WF_54	UCI_Fiber_low	UCI_46	Industrialized
-WF_56	UCI_Fiber_low	UCI_47	Industrialized
-WF_44	UCI_Fiber_high	UCI_48	Industrialized
-WF_201	UCI_Fiber_low	UCI_49	Industrialized
-WF_49	UCI_Fiber_low	UCI_50	Industrialized
-WF_22	UCI_Fiber_high	UCI_51	Industrialized
-WF_39	UCI_Fiber_low	UCI_52	Industrialized
-WF_35	UCI_Fiber_low	UCI_53	Industrialized
-WF_37	UCI_Fiber_low	UCI_54	Industrialized
-WF_24	UCI_Fiber_high	UCI_55	Industrialized
-WF_26	UCI_Fiber_low	UCI_56	Industrialized
-WF_31	UCI_Fiber_high	UCI_57	Industrialized
-WF_27	UCI_Fiber_low	UCI_58	Industrialized
-WF_29	UCI_Fiber_high	UCI_59	Industrialized
-WF_20	UCI_Fiber_low	UCI_60	Industrialized
-WF_33	UCI_Fiber_high	UCI_61	Industrialized
-WF_46	UCI_Fiber_high	UCI_62	Industrialized
-WF_48	UCI_Fiber_high	UCI_63	Industrialized
-WF_41	UCI_Fiber_low	UCI_64	Industrialized
-WF_50	UCI_Fiber_high	UCI_65	Industrialized
-WF_25	UCI_Fiber_low	UCI_66	Industrialized
-WF_71	UCI_Fiber_low	UCI_67	Industrialized
-WF_65	UCI_Fiber_high	UCI_68	Industrialized
-WF_63	UCI_Fiber_high	UCI_69	Industrialized
-WF_70	UCI_Fiber_low	UCI_70	Industrialized
-WF_64	UCI_Fiber_high	UCI_71	Industrialized
-WF_72	UCI_Fiber_low	UCI_72	Industrialized
-WF_51	UCI_Fiber_low	UCI_73	Industrialized
-WF_57	UCI_Fiber_high	UCI_74	Industrialized
-WF_43	UCI_Fiber_high	UCI_75	Industrialized
-WF_53	UCI_Fiber_low	UCI_76	Industrialized
-WF_55	UCI_Fiber_high	UCI_77	Industrialized
-WF_5	UCI_Fiber_high	UCI_78	Industrialized
-WF_17	UCI_Fiber_low	UCI_79	Industrialized
-WF_3	UCI_Fiber_high	UCI_80	Industrialized
-WF_19	UCI_Fiber_low	UCI_81	Industrialized
-WF_13	UCI_Fiber_high	UCI_82	Industrialized
-WF_11	UCI_Fiber_high	UCI_83	Industrialized
-WF_15	UCI_Fiber_high	UCI_84	Industrialized
-WF_9	UCI_Fiber_low	UCI_85	Industrialized
-WF_8	UCI_Fiber_low	UCI_86	Industrialized
-SRR1927149	Tanzania	hadza_1	Non_industrialized
-SRR1929485	Tanzania	hadza_2	Non_industrialized
-SRR1929574	Tanzania	hadza_3	Non_industrialized
-SRR1930121	Tanzania	hadza_4	Non_industrialized
-SRR1930123	Tanzania	hadza_5	Non_industrialized
-SRR1930128	Tanzania	hadza_6	Non_industrialized
-SRR1930134	Tanzania	hadza_7	Non_industrialized
-SRR1930138	Tanzania	hadza_8	Non_industrialized
-SRR1930140	Tanzania	hadza_9	Non_industrialized
-SRR1930143	Tanzania	hadza_10	Non_industrialized
-SRR1930145	Tanzania	hadza_11	Non_industrialized
-SRR1930177	Tanzania	hadza_12	Non_industrialized
-SRR1930179	Tanzania	hadza_13	Non_industrialized
-SRR1930247	Italy	italy_1	Industrialized
-SRR1930248	Italy	italy_2	Industrialized
-SRR1930250	Italy	italy_3	Industrialized
-SRR1930251	Italy	italy_4	Industrialized
-SRR1930253	Italy	italy_5	Industrialized
-SRR1930255	Italy	italy_6	Industrialized
-SRR1931173	Italy	italy_7	Industrialized
-SRR1931178	Italy	italy_8	Industrialized
-SRR1929408	Tanzania	hadza_14	Non_industrialized
-SRR1929484	Tanzania	hadza_15	Non_industrialized
-SRR1929563	Tanzania	hadza_16	Non_industrialized
-SRR1930122	Tanzania	hadza_17	Non_industrialized
-SRR1930132	Tanzania	hadza_18	Non_industrialized
-SRR1930133	Tanzania	hadza_19	Non_industrialized
-SRR1930136	Tanzania	hadza_20	Non_industrialized
-SRR1930141	Tanzania	hadza_21	Non_industrialized
-SRR1930142	Tanzania	hadza_22	Non_industrialized
-SRR1930144	Tanzania	hadza_23	Non_industrialized
-SRR1930149	Tanzania	hadza_24	Non_industrialized
-SRR1930176	Tanzania	hadza_25	Non_industrialized
-SRR6054454	MLVS_cohort	MLVS_1	Industrialized
-SRR6054544	MLVS_cohort	MLVS_2	Industrialized
-SRR6054547	MLVS_cohort	MLVS_3	Industrialized
-SRR6054590	MLVS_cohort	MLVS_4	Industrialized
-SRR6054608	MLVS_cohort	MLVS_5	Industrialized
-SRR6054623	MLVS_cohort	MLVS_6	Industrialized
-SRR6054706	MLVS_cohort	MLVS_7	Industrialized
-SRR6451720	MLVS_cohort	MLVS_8	Industrialized
-SRR6451726	MLVS_cohort	MLVS_9	Industrialized
-SRR6451739	MLVS_cohort	MLVS_10	Industrialized
-SRR6451784	MLVS_cohort	MLVS_11	Industrialized
-SRR6451790	MLVS_cohort	MLVS_12	Industrialized
-SRR6451811	MLVS_cohort	MLVS_13	Industrialized
-SRR6028220	MLVS_cohort	MLVS_14	Industrialized
-SRR6028237	MLVS_cohort	MLVS_15	Industrialized
-SRR6028252	MLVS_cohort	MLVS_16	Industrialized
-SRR6028293	MLVS_cohort	MLVS_17	Industrialized
-SRR6028297	MLVS_cohort	MLVS_18	Industrialized
-SRR6028315	MLVS_cohort	MLVS_19	Industrialized
-SRR6028318	MLVS_cohort	MLVS_20	Industrialized
-SRR6028326	MLVS_cohort	MLVS_21	Industrialized
-SRR6028331	MLVS_cohort	MLVS_22	Industrialized
-SRR6028337	MLVS_cohort	MLVS_23	Industrialized
-SRR6028379	MLVS_cohort	MLVS_24	Industrialized
-SRR6028397	MLVS_cohort	MLVS_25	Industrialized
-SRR6028428	MLVS_cohort	MLVS_26	Industrialized
-SRR6028442	MLVS_cohort	MLVS_27	Industrialized
-SRR6028461	MLVS_cohort	MLVS_28	Industrialized
-SRR6028470	MLVS_cohort	MLVS_29	Industrialized
-SRR6028477	MLVS_cohort	MLVS_30	Industrialized
-SRR6028494	MLVS_cohort	MLVS_31	Industrialized
-SRR6028510	MLVS_cohort	MLVS_32	Industrialized
-SRR6028512	MLVS_cohort	MLVS_33	Industrialized
-SRR6028529	MLVS_cohort	MLVS_34	Industrialized
-SRR6028547	MLVS_cohort	MLVS_35	Industrialized
-SRR6028564	MLVS_cohort	MLVS_36	Industrialized
-SRR6028610	MLVS_cohort	MLVS_37	Industrialized
-SRR6028622	MLVS_cohort	MLVS_38	Industrialized
-SRR6028635	MLVS_cohort	MLVS_39	Industrialized
-SRR6028659	MLVS_cohort	MLVS_40	Industrialized
-SRR1761664	Peru_Lewis	Lewis_1	Non_industrialized
-SRR1761665	Peru_Lewis	Lewis_2	Non_industrialized
-SRR1761666	Peru_Lewis	Lewis_3	Non_industrialized
-SRR1761667	Peru_Lewis	Lewis_4	Non_industrialized
-SRR1761668	Peru_Lewis	Lewis_5	Non_industrialized
-SRR1761669	Peru_Lewis	Lewis_6	Non_industrialized
-SRR1761670	Peru_Lewis	Lewis_7	Non_industrialized
-SRR1761671	Peru_Lewis	Lewis_8	Non_industrialized
-SRR1761673	Peru_Lewis	Lewis_9	Non_industrialized
-SRR1761674	Peru_Lewis	Lewis_10	Non_industrialized
-SRR1761675	Peru_Lewis	Lewis_11	Non_industrialized
-SRR1761676	USA_Lewis	Lewis_12	Industrialized
-SRR1761678	USA_Lewis	Lewis_13	Industrialized
-SRR1761679	USA_Lewis	Lewis_14	Industrialized
-SRR1761680	USA_Lewis	Lewis_15	Industrialized
-SRR1761682	USA_Lewis	Lewis_16	Industrialized
-SRR1761683	USA_Lewis	Lewis_17	Industrialized
-SRR1761685	USA_Lewis	Lewis_18	Industrialized
-SRR1761686	USA_Lewis	Lewis_19	Industrialized
-SRR1761689	USA_Lewis	Lewis_20	Industrialized
-SRR1761690	USA_Lewis	Lewis_21	Industrialized
-SRR1761691	USA_Lewis	Lewis_22	Industrialized
-SRR1761692	USA_Lewis	Lewis_23	Industrialized
-SRR1761693	USA_Lewis	Lewis_24	Industrialized
-SRR1761695	USA_Lewis	Lewis_25	Industrialized
-SRR1761696	USA_Lewis	Lewis_26	Industrialized
-SRR1761697	USA_Lewis	Lewis_27	Industrialized
-SRR1761698	Peru_Lewis	Lewis_28	Non_industrialized
-SRR1761699	Peru_Lewis	Lewis_29	Non_industrialized
-SRR1761700	Peru_Lewis	Lewis_30	Non_industrialized
-SRR1761701	Peru_Lewis	Lewis_31	Non_industrialized
-SRR1761702	Peru_Lewis	Lewis_32	Non_industrialized
-SRR1761703	Peru_Lewis	Lewis_33	Non_industrialized
-SRR1761704	Peru_Lewis	Lewis_34	Non_industrialized
-SRR1761705	Peru_Lewis	Lewis_35	Non_industrialized
-SRR1761707	Peru_Lewis	Lewis_36	Non_industrialized
-SRR1761708	Peru_Lewis	Lewis_37	Non_industrialized
-SRR1761710	Peru_Lewis	Lewis_38	Non_industrialized
-SRR1761711	Peru_Lewis	Lewis_39	Non_industrialized
-SRR1761712	Peru_Lewis	Lewis_40	Non_industrialized
-SRR1761713	Peru_Lewis	Lewis_41	Non_industrialized
-SRR1761715	Peru_Lewis	Lewis_42	Non_industrialized
-SRR1761716	Peru_Lewis	Lewis_43	Non_industrialized
-SRR1761717	Peru_Lewis	Lewis_44	Non_industrialized
-SRR1761718	Peru_Lewis	Lewis_45	Non_industrialized
-SRR1761719	Peru_Lewis	Lewis_46	Non_industrialized
-SRR1761720	Peru_Lewis	Lewis_47	Non_industrialized
-SRR1761721	Peru_Lewis	Lewis_48	Non_industrialized
-SRR1761722	Peru_Lewis	Lewis_49	Non_industrialized
-SRR1761723	Peru_Lewis	Lewis_50	Non_industrialized
-SRR1761724	Peru_Lewis	Lewis_51	Non_industrialized
-SRR1761725	Peru_Lewis	Lewis_52	Non_industrialized
-SRR1761726	Peru_Lewis	Lewis_53	Non_industrialized
-SRR1761727	Peru_Lewis	Lewis_54	Non_industrialized
-SRR1761728	Peru_Lewis	Lewis_55	Non_industrialized
-SRR1761729	Peru_Lewis	Lewis_56	Non_industrialized
-SRR1761731	Peru_Lewis	Lewis_57	Non_industrialized
-SRR1761733	Peru_Lewis	Lewis_58	Non_industrialized
-SRR1761734	USA_Lewis	Lewis_59	Industrialized
-SRR1761735	USA_Lewis	Lewis_60	Industrialized
-SRR1761736	USA_Lewis	Lewis_61	Industrialized
-SRR1761737	USA_Lewis	Lewis_62	Industrialized
-SRR1761738	USA_Lewis	Lewis_63	Industrialized
-SRR1761739	USA_Lewis	Lewis_64	Industrialized
-SRR1761740	USA_Lewis	Lewis_65	Industrialized
-SRR1761741	USA_Lewis	Lewis_66	Industrialized
-SRR1761742	USA_Lewis	Lewis_67	Industrialized
-SRR1761744	USA_Lewis	Lewis_68	Industrialized
-SRR1761746	USA_Lewis	Lewis_69	Industrialized
-SRR1761747	USA_Lewis	Lewis_70	Industrialized
-SRR1761748	USA_Lewis	Lewis_71	Industrialized
-SRR1761749	USA_Lewis	Lewis_72	Industrialized
-SRR1761750	USA_Lewis	Lewis_73	Industrialized
-SRR1761751	USA_Lewis	Lewis_74	Industrialized
-SRR1761752	USA_Lewis	Lewis_75	Industrialized
-SRR1761753	USA_Lewis	Lewis_76	Industrialized
-SRR1761754	USA_Lewis	Lewis_77	Industrialized
-SRR1761755	USA_Lewis	Lewis_78	Industrialized
-SRR1761756	Peru_Lewis	Lewis_79	Non_industrialized
-SRR1761757	Peru_Lewis	Lewis_80	Non_industrialized
-SRR1761758	Peru_Lewis	Lewis_81	Non_industrialized
-SRR1761759	Peru_Lewis	Lewis_82	Non_industrialized
-SRR1761760	Peru_Lewis	Lewis_83	Non_industrialized
-SRR1761761	Peru_Lewis	Lewis_84	Non_industrialized
-SRR1761762	Peru_Lewis	Lewis_85	Non_industrialized
-SRR1761763	Peru_Lewis	Lewis_86	Non_industrialized
-SRR1761765	Peru_Lewis	Lewis_87	Non_industrialized
-SRR1761766	Peru_Lewis	Lewis_88	Non_industrialized
-SRR1761767	Peru_Lewis	Lewis_89	Non_industrialized
-SRR1761768	Peru_Lewis	Lewis_90	Non_industrialized
-SRR1761769	Peru_Lewis	Lewis_91	Non_industrialized
-SRR1761770	Peru_Lewis	Lewis_92	Non_industrialized
-SRR1761771	Peru_Lewis	Lewis_93	Non_industrialized
-SRR1761772	Peru_Lewis	Lewis_94	Non_industrialized
-SRR1761773	Peru_Lewis	Lewis_95	Non_industrialized
-SRR1761774	Peru_Lewis	Lewis_96	Non_industrialized
-SRR1761775	Peru_Lewis	Lewis_97	Non_industrialized
-SRR1761776	Peru_Lewis	Lewis_98	Non_industrialized
-SRR1761777	Peru_Lewis	Lewis_99	Non_industrialized
-SRR1761778	Peru_Lewis	Lewis_100	Non_industrialized
-SRR1761779	Peru_Lewis	Lewis_101	Non_industrialized
-SRR1761743	USA_Lewis	Lewis_102	Industrialized
-SRR1761684	USA_Lewis	Lewis_103	Industrialized
-SRR1761677	USA_Lewis	Lewis_104	Industrialized
-SRR1761745	USA_Lewis	Lewis_105	Industrialized
-SRR1761709	Peru_Lewis	Lewis_106	Non_industrialized
-SRR1761694	USA_Lewis	Lewis_107	Industrialized
-SRR1761732	Peru_Lewis	Lewis_108	Non_industrialized
-SRR1761730	Peru_Lewis	Lewis_109	Non_industrialized
-SRR1761681	USA_Lewis	Lewis_110	Industrialized
-SRR1761688	USA_Lewis	Lewis_111	Industrialized
-SRR1761687	USA_Lewis	Lewis_112	Industrialized
-SRR1761672	Peru_Lewis	Lewis_113	Non_industrialized
-SRR1761714	Peru_Lewis	Lewis_114	Non_industrialized
-SRR1761706	Peru_Lewis	Lewis_115	Non_industrialized
-SRR1761764	Peru_Lewis	Lewis_116	Non_industrialized
-SRS104311	HMP_Fecal	HMP_2	Industrialized
-SRS147139	HMP_Fecal	HMP_4	Industrialized
-SRS014391	HMP_Fecal	HMP_7	Industrialized
-SRS013951	HMP_Fecal	HMP_8	Industrialized
-SRS013951	HMP_Fecal	HMP_9	Industrialized
-SRS014459	HMP_Fecal	HMP_12	Industrialized
-SRS014459	HMP_Fecal	HMP_13	Industrialized
-SRS014683	HMP_Fecal	HMP_16	Industrialized
-SRS014683	HMP_Fecal	HMP_17	Industrialized
-SRS015095	HMP_Fecal	HMP_20	Industrialized
-SRS015065	HMP_Fecal	HMP_21	Industrialized
-SRS019161	HMP_Fecal	HMP_24	Industrialized
-SRS019161	HMP_Fecal	HMP_25	Industrialized
-SRS150029	HMP_Fecal	HMP_27	Industrialized
+study	Sample	Category
+UCI_Fiber_high	UCI_1	Industrialized
+UCI_Fiber_low	UCI_2	Industrialized
+UCI_Fiber_high	UCI_3	Industrialized
+UCI_Fiber_high	UCI_4	Industrialized
+UCI_Fiber_low	UCI_5	Industrialized
+UCI_Fiber_high	UCI_6	Industrialized
+UCI_Fiber_high	UCI_7	Industrialized
+UCI_Fiber_high	UCI_8	Industrialized
+UCI_Fiber_high	UCI_9	Industrialized
+UCI_Fiber_high	UCI_10	Industrialized
+UCI_Fiber_low	UCI_11	Industrialized
+UCI_Fiber_low	UCI_12	Industrialized
+UCI_Fiber_high	UCI_13	Industrialized
+UCI_Fiber_low	UCI_14	Industrialized
+UCI_Fiber_high	UCI_15	Industrialized
+UCI_Fiber_high	UCI_16	Industrialized
+UCI_Fiber_high	UCI_17	Industrialized
+UCI_Fiber_low	UCI_18	Industrialized
+UCI_Fiber_high	UCI_19	Industrialized
+UCI_Fiber_low	UCI_20	Industrialized
+UCI_Fiber_low	UCI_21	Industrialized
+UCI_Fiber_high	UCI_22	Industrialized
+UCI_Fiber_low	UCI_23	Industrialized
+UCI_Fiber_high	UCI_24	Industrialized
+UCI_Fiber_low	UCI_25	Industrialized
+UCI_Fiber_high	UCI_26	Industrialized
+UCI_Fiber_low	UCI_27	Industrialized
+UCI_Fiber_high	UCI_28	Industrialized
+UCI_Fiber_low	UCI_29	Industrialized
+UCI_Fiber_high	UCI_30	Industrialized
+UCI_Fiber_low	UCI_31	Industrialized
+UCI_Fiber_high	UCI_32	Industrialized
+UCI_Fiber_high	UCI_33	Industrialized
+UCI_Fiber_low	UCI_34	Industrialized
+UCI_Fiber_low	UCI_35	Industrialized
+UCI_Fiber_high	UCI_36	Industrialized
+UCI_Fiber_low	UCI_37	Industrialized
+UCI_Fiber_high	UCI_38	Industrialized
+UCI_Fiber_high	UCI_39	Industrialized
+UCI_Fiber_low	UCI_40	Industrialized
+UCI_Fiber_low	UCI_41	Industrialized
+UCI_Fiber_high	UCI_42	Industrialized
+UCI_Fiber_low	UCI_43	Industrialized
+UCI_Fiber_high	UCI_44	Industrialized
+UCI_Fiber_low	UCI_45	Industrialized
+UCI_Fiber_low	UCI_46	Industrialized
+UCI_Fiber_low	UCI_47	Industrialized
+UCI_Fiber_high	UCI_48	Industrialized
+UCI_Fiber_low	UCI_49	Industrialized
+UCI_Fiber_low	UCI_50	Industrialized
+UCI_Fiber_high	UCI_51	Industrialized
+UCI_Fiber_low	UCI_52	Industrialized
+UCI_Fiber_low	UCI_53	Industrialized
+UCI_Fiber_low	UCI_54	Industrialized
+UCI_Fiber_high	UCI_55	Industrialized
+UCI_Fiber_low	UCI_56	Industrialized
+UCI_Fiber_high	UCI_57	Industrialized
+UCI_Fiber_low	UCI_58	Industrialized
+UCI_Fiber_high	UCI_59	Industrialized
+UCI_Fiber_low	UCI_60	Industrialized
+UCI_Fiber_high	UCI_61	Industrialized
+UCI_Fiber_high	UCI_62	Industrialized
+UCI_Fiber_high	UCI_63	Industrialized
+UCI_Fiber_low	UCI_64	Industrialized
+UCI_Fiber_high	UCI_65	Industrialized
+UCI_Fiber_low	UCI_66	Industrialized
+UCI_Fiber_low	UCI_67	Industrialized
+UCI_Fiber_high	UCI_68	Industrialized
+UCI_Fiber_high	UCI_69	Industrialized
+UCI_Fiber_low	UCI_70	Industrialized
+UCI_Fiber_high	UCI_71	Industrialized
+UCI_Fiber_low	UCI_72	Industrialized
+UCI_Fiber_low	UCI_73	Industrialized
+UCI_Fiber_high	UCI_74	Industrialized
+UCI_Fiber_high	UCI_75	Industrialized
+UCI_Fiber_low	UCI_76	Industrialized
+UCI_Fiber_high	UCI_77	Industrialized
+UCI_Fiber_high	UCI_78	Industrialized
+UCI_Fiber_low	UCI_79	Industrialized
+UCI_Fiber_high	UCI_80	Industrialized
+UCI_Fiber_low	UCI_81	Industrialized
+UCI_Fiber_high	UCI_82	Industrialized
+UCI_Fiber_high	UCI_83	Industrialized
+UCI_Fiber_high	UCI_84	Industrialized
+UCI_Fiber_low	UCI_85	Industrialized
+UCI_Fiber_low	UCI_86	Industrialized
+Tanzania	hadza_1	Non_industrialized
+Tanzania	hadza_2	Non_industrialized
+Tanzania	hadza_3	Non_industrialized
+Tanzania	hadza_4	Non_industrialized
+Tanzania	hadza_5	Non_industrialized
+Tanzania	hadza_6	Non_industrialized
+Tanzania	hadza_7	Non_industrialized
+Tanzania	hadza_8	Non_industrialized
+Tanzania	hadza_9	Non_industrialized
+Tanzania	hadza_10	Non_industrialized
+Tanzania	hadza_11	Non_industrialized
+Tanzania	hadza_12	Non_industrialized
+Tanzania	hadza_13	Non_industrialized
+Italy	italy_1	Industrialized
+Italy	italy_2	Industrialized
+Italy	italy_3	Industrialized
+Italy	italy_4	Industrialized
+Italy	italy_5	Industrialized
+Italy	italy_6	Industrialized
+Italy	italy_7	Industrialized
+Italy	italy_8	Industrialized
+Tanzania	hadza_14	Non_industrialized
+Tanzania	hadza_15	Non_industrialized
+Tanzania	hadza_16	Non_industrialized
+Tanzania	hadza_17	Non_industrialized
+Tanzania	hadza_18	Non_industrialized
+Tanzania	hadza_19	Non_industrialized
+Tanzania	hadza_20	Non_industrialized
+Tanzania	hadza_21	Non_industrialized
+Tanzania	hadza_22	Non_industrialized
+Tanzania	hadza_23	Non_industrialized
+Tanzania	hadza_24	Non_industrialized
+Tanzania	hadza_25	Non_industrialized
+MLVS_cohort	MLVS_1	Industrialized
+MLVS_cohort	MLVS_2	Industrialized
+MLVS_cohort	MLVS_3	Industrialized
+MLVS_cohort	MLVS_4	Industrialized
+MLVS_cohort	MLVS_5	Industrialized
+MLVS_cohort	MLVS_6	Industrialized
+MLVS_cohort	MLVS_7	Industrialized
+MLVS_cohort	MLVS_8	Industrialized
+MLVS_cohort	MLVS_9	Industrialized
+MLVS_cohort	MLVS_10	Industrialized
+MLVS_cohort	MLVS_11	Industrialized
+MLVS_cohort	MLVS_12	Industrialized
+MLVS_cohort	MLVS_13	Industrialized
+MLVS_cohort	MLVS_14	Industrialized
+MLVS_cohort	MLVS_15	Industrialized
+MLVS_cohort	MLVS_16	Industrialized
+MLVS_cohort	MLVS_17	Industrialized
+MLVS_cohort	MLVS_18	Industrialized
+MLVS_cohort	MLVS_19	Industrialized
+MLVS_cohort	MLVS_20	Industrialized
+MLVS_cohort	MLVS_21	Industrialized
+MLVS_cohort	MLVS_22	Industrialized
+MLVS_cohort	MLVS_23	Industrialized
+MLVS_cohort	MLVS_24	Industrialized
+MLVS_cohort	MLVS_25	Industrialized
+MLVS_cohort	MLVS_26	Industrialized
+MLVS_cohort	MLVS_27	Industrialized
+MLVS_cohort	MLVS_28	Industrialized
+MLVS_cohort	MLVS_29	Industrialized
+MLVS_cohort	MLVS_30	Industrialized
+MLVS_cohort	MLVS_31	Industrialized
+MLVS_cohort	MLVS_32	Industrialized
+MLVS_cohort	MLVS_33	Industrialized
+MLVS_cohort	MLVS_34	Industrialized
+MLVS_cohort	MLVS_35	Industrialized
+MLVS_cohort	MLVS_36	Industrialized
+MLVS_cohort	MLVS_37	Industrialized
+MLVS_cohort	MLVS_38	Industrialized
+MLVS_cohort	MLVS_39	Industrialized
+MLVS_cohort	MLVS_40	Industrialized
+Peru_Lewis	Lewis_1	Non_industrialized
+Peru_Lewis	Lewis_2	Non_industrialized
+Peru_Lewis	Lewis_3	Non_industrialized
+Peru_Lewis	Lewis_4	Non_industrialized
+Peru_Lewis	Lewis_5	Non_industrialized
+Peru_Lewis	Lewis_6	Non_industrialized
+Peru_Lewis	Lewis_7	Non_industrialized
+Peru_Lewis	Lewis_8	Non_industrialized
+Peru_Lewis	Lewis_9	Non_industrialized
+Peru_Lewis	Lewis_10	Non_industrialized
+Peru_Lewis	Lewis_11	Non_industrialized
+USA_Lewis	Lewis_12	Industrialized
+USA_Lewis	Lewis_13	Industrialized
+USA_Lewis	Lewis_14	Industrialized
+USA_Lewis	Lewis_15	Industrialized
+USA_Lewis	Lewis_16	Industrialized
+USA_Lewis	Lewis_17	Industrialized
+USA_Lewis	Lewis_18	Industrialized
+USA_Lewis	Lewis_19	Industrialized
+USA_Lewis	Lewis_20	Industrialized
+USA_Lewis	Lewis_21	Industrialized
+USA_Lewis	Lewis_22	Industrialized
+USA_Lewis	Lewis_23	Industrialized
+USA_Lewis	Lewis_24	Industrialized
+USA_Lewis	Lewis_25	Industrialized
+USA_Lewis	Lewis_26	Industrialized
+USA_Lewis	Lewis_27	Industrialized
+Peru_Lewis	Lewis_28	Non_industrialized
+Peru_Lewis	Lewis_29	Non_industrialized
+Peru_Lewis	Lewis_30	Non_industrialized
+Peru_Lewis	Lewis_31	Non_industrialized
+Peru_Lewis	Lewis_32	Non_industrialized
+Peru_Lewis	Lewis_33	Non_industrialized
+Peru_Lewis	Lewis_34	Non_industrialized
+Peru_Lewis	Lewis_35	Non_industrialized
+Peru_Lewis	Lewis_36	Non_industrialized
+Peru_Lewis	Lewis_37	Non_industrialized
+Peru_Lewis	Lewis_38	Non_industrialized
+Peru_Lewis	Lewis_39	Non_industrialized
+Peru_Lewis	Lewis_40	Non_industrialized
+Peru_Lewis	Lewis_41	Non_industrialized
+Peru_Lewis	Lewis_42	Non_industrialized
+Peru_Lewis	Lewis_43	Non_industrialized
+Peru_Lewis	Lewis_44	Non_industrialized
+Peru_Lewis	Lewis_45	Non_industrialized
+Peru_Lewis	Lewis_46	Non_industrialized
+Peru_Lewis	Lewis_47	Non_industrialized
+Peru_Lewis	Lewis_48	Non_industrialized
+Peru_Lewis	Lewis_49	Non_industrialized
+Peru_Lewis	Lewis_50	Non_industrialized
+Peru_Lewis	Lewis_51	Non_industrialized
+Peru_Lewis	Lewis_52	Non_industrialized
+Peru_Lewis	Lewis_53	Non_industrialized
+Peru_Lewis	Lewis_54	Non_industrialized
+Peru_Lewis	Lewis_55	Non_industrialized
+Peru_Lewis	Lewis_56	Non_industrialized
+Peru_Lewis	Lewis_57	Non_industrialized
+Peru_Lewis	Lewis_58	Non_industrialized
+USA_Lewis	Lewis_59	Industrialized
+USA_Lewis	Lewis_60	Industrialized
+USA_Lewis	Lewis_61	Industrialized
+USA_Lewis	Lewis_62	Industrialized
+USA_Lewis	Lewis_63	Industrialized
+USA_Lewis	Lewis_64	Industrialized
+USA_Lewis	Lewis_65	Industrialized
+USA_Lewis	Lewis_66	Industrialized
+USA_Lewis	Lewis_67	Industrialized
+USA_Lewis	Lewis_68	Industrialized
+USA_Lewis	Lewis_69	Industrialized
+USA_Lewis	Lewis_70	Industrialized
+USA_Lewis	Lewis_71	Industrialized
+USA_Lewis	Lewis_72	Industrialized
+USA_Lewis	Lewis_73	Industrialized
+USA_Lewis	Lewis_74	Industrialized
+USA_Lewis	Lewis_75	Industrialized
+USA_Lewis	Lewis_76	Industrialized
+USA_Lewis	Lewis_77	Industrialized
+USA_Lewis	Lewis_78	Industrialized
+Peru_Lewis	Lewis_79	Non_industrialized
+Peru_Lewis	Lewis_80	Non_industrialized
+Peru_Lewis	Lewis_81	Non_industrialized
+Peru_Lewis	Lewis_82	Non_industrialized
+Peru_Lewis	Lewis_83	Non_industrialized
+Peru_Lewis	Lewis_84	Non_industrialized
+Peru_Lewis	Lewis_85	Non_industrialized
+Peru_Lewis	Lewis_86	Non_industrialized
+Peru_Lewis	Lewis_87	Non_industrialized
+Peru_Lewis	Lewis_88	Non_industrialized
+Peru_Lewis	Lewis_89	Non_industrialized
+Peru_Lewis	Lewis_90	Non_industrialized
+Peru_Lewis	Lewis_91	Non_industrialized
+Peru_Lewis	Lewis_92	Non_industrialized
+Peru_Lewis	Lewis_93	Non_industrialized
+Peru_Lewis	Lewis_94	Non_industrialized
+Peru_Lewis	Lewis_95	Non_industrialized
+Peru_Lewis	Lewis_96	Non_industrialized
+Peru_Lewis	Lewis_97	Non_industrialized
+Peru_Lewis	Lewis_98	Non_industrialized
+Peru_Lewis	Lewis_99	Non_industrialized
+Peru_Lewis	Lewis_100	Non_industrialized
+Peru_Lewis	Lewis_101	Non_industrialized
+USA_Lewis	Lewis_102	Industrialized
+USA_Lewis	Lewis_103	Industrialized
+USA_Lewis	Lewis_104	Industrialized
+USA_Lewis	Lewis_105	Industrialized
+Peru_Lewis	Lewis_106	Non_industrialized
+USA_Lewis	Lewis_107	Industrialized
+Peru_Lewis	Lewis_108	Non_industrialized
+Peru_Lewis	Lewis_109	Non_industrialized
+USA_Lewis	Lewis_110	Industrialized
+USA_Lewis	Lewis_111	Industrialized
+USA_Lewis	Lewis_112	Industrialized
+Peru_Lewis	Lewis_113	Non_industrialized
+Peru_Lewis	Lewis_114	Non_industrialized
+Peru_Lewis	Lewis_115	Non_industrialized
+Peru_Lewis	Lewis_116	Non_industrialized
+HMP_Fecal	HMP_2	Industrialized
+HMP_Fecal	HMP_4	Industrialized
+HMP_Fecal	HMP_7	Industrialized
+HMP_Fecal	HMP_8	Industrialized
+HMP_Fecal	HMP_9	Industrialized
+HMP_Fecal	HMP_12	Industrialized
+HMP_Fecal	HMP_13	Industrialized
+HMP_Fecal	HMP_16	Industrialized
+HMP_Fecal	HMP_17	Industrialized
+HMP_Fecal	HMP_20	Industrialized
+HMP_Fecal	HMP_21	Industrialized
+HMP_Fecal	HMP_24	Industrialized
+HMP_Fecal	HMP_25	Industrialized
+HMP_Fecal	HMP_27	Industrialized

--- a/tree.R
+++ b/tree.R
@@ -692,6 +692,7 @@ rf_competition <- function(df, metadata, parent_descendent_competition, feature_
     colnames()
   # merge node abundance + children abundance with metadata
   merged_data <- merge(df, metadata, by.x = "row.names", by.y = "subject_id")
+  merged_data <- merged_data %>% tidyr::drop_na()
   # clean node names so ranger doesnt throw an error
   merged_data <- tibble::column_to_rownames(merged_data, var = "Row.names")
   data_colnames <- colnames(merged_data)

--- a/tree.R
+++ b/tree.R
@@ -58,10 +58,25 @@ read_in_metadata <- function(input, subject_identifier, label) {
   # read in metadata, and select only the subject identifier and
   # feature of interest. Drop NA samples.
   metadata <- suppressMessages(readr::read_delim(file = input, delim = delim)) %>%
-    dplyr::select(., subject_identifier, label) %>%
     dplyr::rename(., "subject_id" = subject_identifier) %>%
     rename(., "feature_of_interest" = label) %>%
-    tidyr::drop_na()
+    dplyr::filter(., !is.na(subject_id)) %>%
+    janitor::clean_names()
+  
+  ## check and make sure there are not too many metadata columns
+  ## we will allow 10 total columns (8 columns of additional covariates)
+  if (ncol(metadata) > 10) {
+    stop("Please only provide subject, label, and up to 8 additional covariates in the metadata file.")
+  }
+  
+  ## notify user what covariates we find, if any
+  if (ncol(metadata) > 2) {
+    cat("You supplied covariates to consider for the RF competition. They are:\n")
+    print(metadata %>% 
+            dplyr::select(., -subject_id, -feature_of_interest) %>%
+            colnames())
+  }
+  
   ## this is an effort to clean names for the RF later, which will complain big time
   ## if there are symbols or just numbers in your subject IDs
   metadata$subject_id <- metadata$subject_id %>% janitor::make_clean_names(use_make_names = F)
@@ -126,6 +141,9 @@ read_in_hierarchical_data <- function(input, metadata, cores) {
 # write summarized abundance files for each level except taxa_tree
 write_summary_files <- function(input, metadata, output) {
   
+  ## select "base" (no covariates) metadata file
+  metadata <- metadata %>% dplyr::select(., subject_id, feature_of_interest)
+  
   ## write file for TaxaHFE version 1
   version1 <- input %>%
     dplyr::filter(., name != "taxaTree") %>%
@@ -180,6 +198,9 @@ write_summary_files <- function(input, metadata, output) {
 ## write files for old_HFE =====================================================
 # write old files for the Oudah program
 write_old_hfe <- function(input, output) {
+  
+  ## select "base" (no covariates) metadata file
+  metadata <- metadata %>% dplyr::select(., subject_id, feature_of_interest)
   
   max_levels <- max(input[["depth"]])
   ## start at 2 to ignore taxa_tree depth (meaningless node)
@@ -663,6 +684,12 @@ calc_class_frequencies <- function(input, feature_type, feature = "feature_of_in
 ## rf competition function =====================================================
 # TODO: document these inputs
 rf_competition <- function(df, metadata, parent_descendent_competition, feature_of_interest = "feature_of_interest", subject_identifier = "subject_id", feature_type, sample_fraction, ncores, nperm) {
+  
+  ## get a list of the covariates in order to remove them from the RF winners
+  ## later, so the only RF winners are taxa
+  covariates <- metadata %>% 
+    dplyr::select(., -subject_id, -feature_of_interest) %>%
+    colnames()
   # merge node abundance + children abundance with metadata
   merged_data <- merge(df, metadata, by.x = "row.names", by.y = "subject_id")
   # clean node names so ranger doesnt throw an error
@@ -691,13 +718,14 @@ rf_competition <- function(df, metadata, parent_descendent_competition, feature_
     ranger::ranger(response_formula, data = merged_data, importance = "impurity_corrected", seed = seed, sample.fraction = sample_fraction, replace = TRUE, num.threads = ncores)$variable.importance %>%
       as.data.frame() %>%
       dplyr::rename(., "importance" = ".") %>%
-      tibble::rownames_to_column(var = "taxa")
+      tibble::rownames_to_column(var = "taxa") 
   }
   
   # run the above function across nperm random seeds and average the vip scores
   model_importance <- purrr::map_df(sample(1:1000, nperm), run_ranger) %>%
     dplyr::group_by(taxa) %>%
-    dplyr::summarise(., average = mean(importance))
+    dplyr::summarise(., average = mean(importance)) %>% 
+    dplyr::filter(., taxa %!in% covariates)
   
   # if this is not a parent vs descendent competition
   # return the ids of competitors whose scores meet the following thresholds:
@@ -780,6 +808,10 @@ write_output_file <- function(flattened_df, metadata, output_location, file_suff
 # if disable_super_filter is TRUE, the super filter competition wasn't run, and only one output will be generated
 # if both_outputs is FALSE, one file will be produced with the final level of competition that occurred
 generate_outputs <- function(tree, metadata, col_names, output_location, disable_super_filter, write_both_outputs, write_old_files, write_flattened_df_backup, ncores) {
+  
+  ## select "base" (no covariates) metadata file
+  metadata <- metadata %>% dplyr::select(., subject_id, feature_of_interest)
+  
   # flatten tree back into metadata, and assign original column names from hData to the sample columns
   flattened_df <- flatten_tree_with_metadata(tree)
   colnames(flattened_df)[11:NCOL(flattened_df)] <- col_names


### PR DESCRIPTION
Now, any additional columns that are in your metadata file are treated as covariates for the RF models. You can supply up to 8 covariates!