### PR TITLE
ability to bypass dietML in taxaHFE-ML, and output train flattened df

### DIFF
--- a/taxaHFE-ML/leakfree_taxaHFE.R
+++ b/taxaHFE-ML/leakfree_taxaHFE.R
@@ -224,5 +224,9 @@ cat(" Outputs written! TaxaHFE completed. \n")
 ## DIETML MACHINE LEARNING
 ##########################
 
-source("/scripts/dietML.R")
-
+if (opt$model == "none") {
+  cat("Model set to none. DietML not run")
+  save.image(file = paste0(dirname(opt$OUTPUT), "/taxaHFE_r_workspace.rds"))
+} else { 
+  source("/scripts/dietML.R")
+}

--- a/tree.R
+++ b/tree.R
@@ -844,9 +844,17 @@ generate_outputs <- function(tree, metadata, col_names, output_location, disable
 
   ## save flattened DF to come back to
   if (write_flattened_df_backup == TRUE) {
+    if (exists("tr_te_split", envir = .GlobalEnv)) { 
+      if (count == 1) {
+        vroom::vroom_write(x = flattened_df,
+                      file =  paste0(tools::file_path_sans_ext(output_location), "_raw_data.tsv.gz"),
+                      num_threads = ncores)
+      }
+  } else {
     vroom::vroom_write(x = flattened_df,
                       file =  paste0(tools::file_path_sans_ext(output_location), "_raw_data.tsv.gz"),
                       num_threads = ncores)
+    }
   }
 }
 


### PR DESCRIPTION
**1. bypass dietML with model = none** 
run taxahfe-ml without dietml if set model to "none". This will save the RDS at the end of taxaHFE-ml
**3.  if taxahfe-ml, output training flattened df** 
before, the flattened df that was output was the testing one...which does not tell us a lot of information because the competitions are fake (the switches in leakfree_taxahfe.R kind of "bypass" the competitions for the test data)