### PR TITLE
62 clean up taxahfe ml code

### DIFF
--- a/taxaHFE-ML/dietML.R
+++ b/taxaHFE-ML/dietML.R
@@ -56,18 +56,18 @@ if (dir.exists(paste0(dirname(opt$OUTPUT), "/ml_analysis")) == TRUE) {
   setwd(paste0(dirname(opt$OUTPUT), "/ml_analysis"))
 }
 
-
-## check for input and break if not found
-if (!exists(x = "train_data") & !exists(x = "flattened_df_test")) { 
-  stop("Train data or Test data not found.\n")
-}
+## read in inputs
+train_data <- readr::read_csv(file =  paste0(tools::file_path_sans_ext(opt$OUTPUT), "_train.csv"))
+flattened_df_test <- readr::read_delim(file =  paste0(tools::file_path_sans_ext(opt$OUTPUT), "_test_raw_data.tsv.gz"))
 
 ## format input ================================================================
 
 ## make sure test and train have the same features
 flattened_df_test$name <- janitor::make_clean_names(flattened_df_test$name)
 test_data <- flattened_df_test %>%
+  # only select rows with same feature names as train_data features
   dplyr::filter(., name %in% colnames(train_data)) %>%
+  # only select columns in test_metadata
   dplyr::select(., name, dplyr::any_of(test_metadata$subject_id)) %>%
   tibble::remove_rownames() %>%
   tibble::column_to_rownames(., var = "name") %>%

--- a/tree.R
+++ b/tree.R
@@ -774,12 +774,8 @@ write_output_file <- function(flattened_df, metadata, output_location, file_suff
     tibble::rownames_to_column(var = "subject_id")
 
   output <- merge(metadata, output, by = "subject_id")
-  ## write variable to global env if doing taxaHFE-ML
-  if (exists("tr_te_split", envir = .GlobalEnv)) { 
-    assign(x = paste0("output_", count, gsub(pattern = ".csv", replacement = "", x = file_suffix)), output, envir = .GlobalEnv) 
-    } else {
-      readr::write_delim(file = paste0(tools::file_path_sans_ext(output_location), file_suffix), x = output, delim = ",")
-    }
+  readr::write_delim(file = paste0(tools::file_path_sans_ext(output_location), file_suffix), x = output, delim = ",")
+
 }
 
 # generate the outputs
@@ -816,23 +812,10 @@ generate_outputs <- function(tree, metadata, col_names, output_location, disable
     write_output_file(flattened_winners, metadata, output_location, "_no_sf.csv")
   }
 
-  ## report number of features for the original program or just the training
-  ## features for taxaHFE-ML
-  if (exists("tr_te_split", envir = .GlobalEnv)) {
-    if (count == 1) {
-      cat(" Number of features selcted from training: ", nrow(flattened_winners), "\n") 
-      cat(" Number of samples used for training: ", (ncol(hData_split) - 1), "\n")
-      cat(" Number of samples used for testing: ", ((ncol(hData) - 1) - (ncol(hData_split) - 1)), "\n")
-      if (disable_super_filter != TRUE) { 
-        cat("\n Number of features selcted from training (super filter): ", nrow(flattened_sf_winners), "\n") 
-      }
-    } 
-  } else {
-    cat(" Features (no super filter): ", nrow(flattened_winners), "\n")
+  cat(" Features (no super filter): ", nrow(flattened_winners), "\n")
   if (disable_super_filter != TRUE) {
     cat("\n Features (super filter): ", nrow(flattened_sf_winners), "\n")
     }
-  }
 
   ## write old files  ============================================================
   if (write_old_files == TRUE) {
@@ -844,17 +827,9 @@ generate_outputs <- function(tree, metadata, col_names, output_location, disable
 
   ## save flattened DF to come back to
   if (write_flattened_df_backup == TRUE) {
-    if (exists("tr_te_split", envir = .GlobalEnv)) { 
-      if (count == 1) {
-        vroom::vroom_write(x = flattened_df,
-                      file =  paste0(tools::file_path_sans_ext(output_location), "_raw_data.tsv.gz"),
-                      num_threads = ncores)
-      }
-  } else {
     vroom::vroom_write(x = flattened_df,
                       file =  paste0(tools::file_path_sans_ext(output_location), "_raw_data.tsv.gz"),
-                      num_threads = ncores)
-    }
+                      num_threads = ncores) 
   }
 }
 


### PR DESCRIPTION
Removed code that had tree.R writing to global env.

1. reverted code back to version 2.0 code, with some minor changes.
- set trim = 0.0 (we made this change already in a newer branch, i just started at out version 2.0 release for tree.R code)
- remove any instance of sample_fraction and calc_class_frequences
- make sure seed, if using system time, is written to opt (even though i know we are moving away from opt). This way we can look back and see what exact seed was used.

2. Changed leakfree_taxaHFE.R to use the functions themselves to change the outputs for test data and train data. Writes it all to files. Annotated these switch() functions for clarity.

3. changed dietML files to read in the outputs written by leakfree_taxaHFE (maybe we should changes these names to taxaHFE (orig) and taxaHFE-ML (leakfree_taxahfe)).
