### PR TITLE
70 bug in nperm over 100

### DIFF
--- a/tree.R
+++ b/tree.R
@@ -695,7 +695,7 @@ rf_competition <- function(df, metadata, parent_descendent_competition, feature_
   }
   
   # run the above function across nperm random seeds and average the vip scores
-  model_importance <- purrr::map_df(sample(1:1000, nperm), run_ranger) %>%
+  model_importance <- purrr::map_df(sample(1:1000000, nperm), run_ranger) %>%
     dplyr::group_by(taxa) %>%
     dplyr::summarise(., average = mean(importance)) %>% 
     dplyr::filter(., taxa %!in% covariates)


### PR DESCRIPTION
Bug fixed! Increased sample to 1:1000000. 

To do - might be nice to set some error messaging if someone provides a number outside 1: (1000000 / 10). If they provide a nperm outside that, the super filter will not work.
