### PR TITLE
Add some NA checks to read in

### DIFF
--- a/lib/tree.R
+++ b/lib/tree.R
@@ -65,11 +65,12 @@ read_in_metadata <- function(input, subject_identifier, label, feature_type, ran
   # feature of interest. Drop NA samples.
   metadata <- suppressMessages(readr::read_delim(file = input, delim = delim)) %>%
     dplyr::rename(., "subject_id" = subject_identifier) %>%
-    rename(., "feature_of_interest" = label)
+    rename(., "feature_of_interest" = label) %>% 
+    janitor::clean_names()
   
   ## make check for NAs and warn user how many rows were dropped
   original_row_count <- nrow(metadata)
-  metadata <- metadata %>% tidyr::drop_na() %>% janitor::clean_names()
+  metadata <- metadata %>% tidyr::drop_na()
   new_row_count <- nrow(metadata)
   
   if (original_row_count > new_row_count) {


### PR DESCRIPTION
- for metadata, I check for NAs and remove them, and then warn the user about the removal. I can see many more instances for metadata, where I have NAs but I just want the program to solider on.

``` ## make check for NAs and warn user how many rows were dropped
  original_row_count <- nrow(metadata)
  metadata <- metadata %>% tidyr::drop_na() %>% janitor::clean_names()
  new_row_count <- nrow(metadata)
  
  if (original_row_count > new_row_count) {
    warning(paste0((original_row_count - new_row_count), " number of metadata rows were dropped because they contained NAs"), immediate. = TRUE)
    if ((original_row_count - new_row_count) <= 0) {
      stop("All rows were dropped in NA removal.")
    }
  }
```
- for hData, I stop the program if NAs are found. That one is a little weirder, users should really have a complete dataset.
```
## check and make sure there are no NAs in hData
  if (anyNA(hData)) {
    stop("Please remove NAs from your hierarchical data input.")
  }
```