### PR TITLE
89 functionalize dietml commands

### DIFF
--- a/cmd/summarized_levels.R
+++ b/cmd/summarized_levels.R
@@ -44,28 +44,30 @@ train_metadata <- rsample::training(tr_te_split)
 test_metadata  <- rsample::testing(tr_te_split)
 
 # Run taxaHFE-ML
-method_levels(hdata = hData,
-              metadata = metadata,
-              prevalence = opts$prevalence,
-              abundance = opts$prevalence,
-              lowest_level = opts$lowest_level,
-              max_level = opts$max_level,
-              cor_level = 0.1, # low cor_level for speed - makes almost everything a correlation battle (becase the battles dont matter, only the tree)
-              ncores = opts$ncores,
-              feature_type = opts$feature_type,
-              nperm = opts$nperm,
-              disable_super_filter = opts$disable_super_filter,
-              write_both_outputs = opts$write_both_outputs,
-              write_flattened_tree = opts$write_flattened_tree,
-              target_list = diet_ml_inputs,
-              col_names = colnames(hData)[2:NCOL(hData)],
-              output = opts$OUTPUT,
-              seed = opts$seed,
-              random_effects = random_effects
+diet_ml_inputs <- method_levels(
+  hdata = hData,
+  metadata = metadata,
+  prevalence = opts$prevalence,
+  abundance = opts$prevalence,
+  lowest_level = opts$lowest_level,
+  max_level = opts$max_level,
+  cor_level = 0.1,
+  # low cor_level for speed - makes almost everything a correlation battle (becase the battles dont matter, only the tree)
+  ncores = opts$ncores,
+  feature_type = opts$feature_type,
+  nperm = opts$nperm,
+  disable_super_filter = opts$disable_super_filter,
+  write_both_outputs = opts$write_both_outputs,
+  write_flattened_tree = opts$write_flattened_tree,
+  target_list = diet_ml_inputs,
+  col_names = colnames(hData)[2:NCOL(hData)],
+  output = opts$OUTPUT,
+  seed = opts$seed,
+  random_effects = opts$random_effects
 )
 
 ## make sure test train in each item of list
-split_train_data(target_list = diet_ml_inputs, attribute_name = "train_test_attr", seed = opts$seed)
+diet_ml_inputs <- split_train_data(target_list = diet_ml_inputs, attribute_name = "train_test_attr", seed = opts$seed)
 
 ## create df for dietML to parse
 diet_ml_input_df <- extract_attributes(items_list = diet_ml_inputs)

--- a/cmd/taxa_hfe.R
+++ b/cmd/taxa_hfe.R
@@ -40,7 +40,8 @@ hData <- read_in_hierarchical_data(input = opts$DATA,
 
 
 # Run TaxaHFE
-method_taxa_hfe(hdata = hData,
+diet_ml_inputs <- method_taxa_hfe(
+  hdata = hData,
   metadata = metadata,
   prevalence = opts$prevalence,
   abundance = opts$abundance,
@@ -58,5 +59,5 @@ method_taxa_hfe(hdata = hData,
   output = opts$OUTPUT,
   seed = opts$seed,
   random_effects = opts$random_effects
-  )
+)
 

--- a/cmd/taxa_hfe_ml.R
+++ b/cmd/taxa_hfe_ml.R
@@ -83,4 +83,20 @@ diet_ml_input_df <- extract_attributes(items_list = diet_ml_inputs)
 write_list_to_csv(target_list = diet_ml_inputs, directory = dirname(opts$OUTPUT))
 
 ## pass to dietML if selected
-run_diet_ml(input_df = diet_ml_input_df, n_repeat = opts$permute)
+run_diet_ml(input_df = diet_ml_input_df, 
+            n_repeat = opts$permute, 
+            model = opts$model,
+            type = opts$feature_type,
+            seed = opts$seed,
+            model = opts$model,
+            random_effects = opts$random_effects,
+            folds = opts$folds,
+            cor_level = opts$cor_level,
+            ncores = opts$ncores,
+            tune_length = opts$tune_length,
+            tune_stop = opts$tune_stop,
+            tune_time = opts$tune_time,
+            metric = opts$metric,
+            label = opts$label,
+            output = opts$OUTPUT,
+            shap = opts$shap)

--- a/cmd/taxa_hfe_ml.R
+++ b/cmd/taxa_hfe_ml.R
@@ -45,35 +45,36 @@ train_metadata <- rsample::training(tr_te_split)
 test_metadata  <- rsample::testing(tr_te_split)
 
 # Run taxaHFE-ML
-method_taxa_hfe_ml(hdata = hData,
-                  metadata = metadata,
-                  prevalence = opts$prevalence, 
-                  abundance = opts$abundance,
-                  lowest_level = opts$lowest_level,
-                  max_level = opts$max_level,
-                  cor_level = opts$cor_level,
-                  ncores = opts$ncores,
-                  feature_type = opts$feature_type,
-                  nperm = opts$nperm,
-                  disable_super_filter = opts$disable_super_filter,
-                  write_both_outputs = opts$write_both_outputs,
-                  write_flattened_tree = opts$write_flattened_tree,
-                  train_split = opts$train_split,
-                  model = opts$model,
-                  folds = opts$folds,
-                  metric = opts$metric,
-                  tune_length = opts$tune_length,
-                  tune_time = opts$tune_time,
-                  tune_stop = opts$tune_stop,
-                  shap = opts$shap,
-                  target_list = diet_ml_inputs,
-                  output = opts$OUTPUT,
-                  seed = opts$seed,
-                  random_effects = opts$random_effects
+diet_ml_inputs <- method_taxa_hfe_ml(
+  hdata = hData,
+  metadata = metadata,
+  prevalence = opts$prevalence,
+  abundance = opts$abundance,
+  lowest_level = opts$lowest_level,
+  max_level = opts$max_level,
+  cor_level = opts$cor_level,
+  ncores = opts$ncores,
+  feature_type = opts$feature_type,
+  nperm = opts$nperm,
+  disable_super_filter = opts$disable_super_filter,
+  write_both_outputs = opts$write_both_outputs,
+  write_flattened_tree = opts$write_flattened_tree,
+  train_split = opts$train_split,
+  model = opts$model,
+  folds = opts$folds,
+  metric = opts$metric,
+  tune_length = opts$tune_length,
+  tune_time = opts$tune_time,
+  tune_stop = opts$tune_stop,
+  shap = opts$shap,
+  target_list = diet_ml_inputs,
+  output = opts$OUTPUT,
+  seed = opts$seed,
+  random_effects = opts$random_effects
 )
 
 ## make sure test train in each item of list
-split_train_data(target_list = diet_ml_inputs, attribute_name = "train_test_attr", seed = opts$seed)
+diet_ml_inputs <- split_train_data(target_list = diet_ml_inputs, attribute_name = "train_test_attr", seed = opts$seed)
 
 ## create df for dietML to parse
 diet_ml_input_df <- extract_attributes(items_list = diet_ml_inputs)
@@ -86,9 +87,8 @@ write_list_to_csv(target_list = diet_ml_inputs, directory = dirname(opts$OUTPUT)
 run_diet_ml(input_df = diet_ml_input_df, 
             n_repeat = opts$permute, 
             model = opts$model,
-            type = opts$feature_type,
+            feature_type = opts$feature_type,
             seed = opts$seed,
-            model = opts$model,
             random_effects = opts$random_effects,
             folds = opts$folds,
             cor_level = opts$cor_level,

--- a/lib/methods.R
+++ b/lib/methods.R
@@ -59,7 +59,7 @@ method_taxa_hfe <- function(hdata, metadata, prevalence, abundance,
   )
   
   ## store taxaHFE outputs in list
-  diet_ml_inputs <<- store_diet_ml_inputs(target_list = diet_ml_inputs,
+  diet_ml_inputs <- store_diet_ml_inputs(target_list = diet_ml_inputs,
     object = flattened_df,
     super_filter = ifelse(disable_super_filter, "no_sf", "sf"),
     method = "taxa_hfe",
@@ -68,6 +68,7 @@ method_taxa_hfe <- function(hdata, metadata, prevalence, abundance,
     seed = seed
     )
   
+  return(diet_ml_inputs)
 }
 
 method_taxa_hfe_ml <- function(hdata, metadata, prevalence, abundance,
@@ -155,20 +156,22 @@ method_taxa_hfe_ml <- function(hdata, metadata, prevalence, abundance,
   test_data_for_diet_ml <- test_data[names(train_data_for_diet_ml)]
 
   ## store data in list of data for dietML
-  diet_ml_inputs <<- store_diet_ml_inputs(target_list = diet_ml_inputs,
+  diet_ml_inputs <- store_diet_ml_inputs(target_list = diet_ml_inputs,
     object = train_data_for_diet_ml,
     super_filter = ifelse(disable_super_filter, "no_sf", "sf"),
     method = "taxa_hfe_ml",
     train_test_attr = "train",
     level_n = NA,
     seed = seed)
-  diet_ml_inputs <<- store_diet_ml_inputs(target_list = diet_ml_inputs,
+  diet_ml_inputs <- store_diet_ml_inputs(target_list = diet_ml_inputs,
     object = test_data_for_diet_ml,
     super_filter = ifelse(disable_super_filter, "no_sf", "sf"),
     method = "taxa_hfe_ml",
     train_test_attr = "test",
     level_n = NA,
     seed = seed)
+  
+  return(diet_ml_inputs)
 
 }
   
@@ -210,11 +213,13 @@ method_levels <- function(hdata, metadata, prevalence, abundance,
   colnames(flattened_df)[11:NCOL(flattened_df)] <- col_names
   
   ## attach the summary files to dietML_input list
-  generate_summary_files(input = flattened_df, 
+  diet_ml_inputs <- generate_summary_files(input = flattened_df, 
                          metadata = metadata, 
                          target_list = diet_ml_inputs, 
                          disable_super_filter = ifelse(disable_super_filter, "no_sf", "sf"),
                          seed = seed
                         )
+  
+  return(diet_ml_inputs)
 }
 

--- a/lib/options.R
+++ b/lib/options.R
@@ -48,7 +48,7 @@ argument_groups <- list(
     desc="Options to pass to TaxaHFE-ML for machine learning and SHAP analysis of TaxaHFE features",
     args=list(
       train_split=list("--train_split", type="numeric", metavar="<numeric>", default="0.8", help="Percentage of samples to use for training"),
-      model=list("--model", type="character", metavar="<string>", default="rf", choices=c("rf", "enet", "none"), help="ML model to use"),
+      model=list("--model", type="character", metavar="<string>", default="rf", choices=c("rf", "enet"), help="ML model to use"),
       folds=list("--folds", type="numeric", metavar="<numeric>", default="10", help="Number of CV folds for tuning"),
       metric=list("--metric", type="character", metavar="<string>", default="bal_accuracy", choices=c("roc_auc", "bal_accuracy", "accuracy", "mae", "rmse", "rsq", "kap", "f_meas", "ccc"), help="Metric to optimize"),
       tune_length=list("--tune_length", type="numeric", metavar="<numeric>", default="80", help="Number of hyperparameter combinations to sample"),

--- a/lib/tree.R
+++ b/lib/tree.R
@@ -1230,3 +1230,30 @@ prep_re_data <- function(input, feature_type, abund) {
   } 
 }
   
+pass_to_dietML <- function(train, test, model, program, type) {
+  
+  ## check and make sure diet_ml_input_df exists
+  if (!exists("diet_ml_input_df") | nrow(diet_ml_input_df) < 1) {
+    stop(paste0("Nothing passed to dietML."))
+  } 
+  
+  ## check for outdir and make if not there
+  if (dir.exists(paste0(dirname(opts$OUTPUT), "/ml_analysis")) != TRUE) {
+    dir.create(path = paste0(dirname(opts$OUTPUT), "/ml_analysis"))
+  }
+  
+  
+  ## check for label
+  if ("feature_of_interest" %in% colnames(train_data) == FALSE & "feature_of_interest" %in% colnames(test_data) == FALSE) {
+    stop(paste0("label not found in training AND testing data"))
+  } 
+  
+  ## check if classification was mis-specified
+  if (type == "factor") {
+    type <<- "classification"
+    if(length(levels(as.factor(metadata$feature_of_interest))) > 9)
+      stop("You are trying to predict 10 or more classes. That is a bit much. Did you mean to do regression?")
+  } else {
+    type <<- "regression"
+  }
+}


### PR DESCRIPTION
This converts the R scripts for dietML and dietML ranger and SHAP scripts to be functions. Address issues #89 and #90 i think. It also mostly code that writes to the global env. Specifically:
- updates to function run_diet_ml
- creation of function pass_to_dietml
- creation of function run_null_model and run_dietML_ranger
- creation of function shap_analysis

The stack for dietML functions is: create dietml_inputs list > run_diet_ml > pass_to_dietML > run_null_model & run_dietML_ranger > shap_analysis.

TO DO still:
- make function for enet model (right now only ```--model rf``` will work, which is the default
- do something about ```write_both_outputs```. This only works if you run taxaHFE with no ML or anything else...just the old school taxaHFEv2 version of the algorithm. I think we could tweak this function so that if it is called, it will pass both the sf and no_sf files to ML. 
- create a single binary (something like docker run aoliver44/taxahfe:latest --method ml,rm,base --more_flags (i'm open to other suggestions, but I think it would be could to accept multiple values here...we should discuss more)
- clean up code and write documentation