### PR TITLE
97 shap data save

### DIFF
--- a/lib/tree.R
+++ b/lib/tree.R
@@ -1654,6 +1654,14 @@ shap_analysis <- function(label, output, model, filename, shap_inputs, train, te
   shap.error.occured <- FALSE
   error_message <- NULL
   output_dir <- file.path(dirname(output), "ml_analysis")
+
+  ## save some initial inputs to env, in case the below 
+  ## shap analysis does not finish. Occasionaly it does not finish on
+  ## the "test" dataset. Which is fine, i cant think of why that is used.
+  ## But if it fails, we still want as much data returned as possible, so 
+  ## that is why we return everything prior to returning the test shap data
+  assign("split_from_data_frame", split_from_data_frame, envir = shap_plot_env)
+  assign("label", label, envir = shap_plot_env)
   
   # --- Define prediction wrapper (pfun) ---
   pfun <- NULL
@@ -1734,10 +1742,7 @@ shap_analysis <- function(label, output, model, filename, shap_inputs, train, te
         assign(paste0("plot_", shap_data_subsets[[i]][[2]]), plot, envir = shap_plot_env)
         
       }
-      
-      ## more things to save, outside the for-loop
-      assign("split_from_data_frame", split_from_data_frame, envir = shap_plot_env)
-      assign("label", label, envir = shap_plot_env)
+
       
     }, error = function(e) {
       shap.error.occured <<- TRUE

--- a/lib/tree.R
+++ b/lib/tree.R
@@ -1749,7 +1749,14 @@ shap_analysis <- function(label, output, model, filename, shap_inputs, train, te
   # --- Save and return results ---
   if (shap.error.occured) {
     message("❌ SHAP analysis could not be completed.")
-    if (!is.null(error_message)) {
+    if (!is.null(error_message)) { 
+      ## attempt to still return what was written to shap_plot_env
+      save(list = ls(envir = shap_plot_env), 
+      envir = shap_plot_env,
+      file = file.path(paste0(output_dir, "/shap_inputs_", filename, ".RData")),
+      compress = "gzip"
+    )
+      ## return error message
       message("Error: ", error_message)
     }
   } else {


### PR DESCRIPTION
Move where shap data is saved
put the saving of shap data inputs higher in the code. The trip point is the shap test data. We want the saving of the inputs to be before the saving of the test data, in case that triggers an error (before, in rare cases, the shap test data doesnt finish, and the loop will error out instead of write the inputs).