### PR TITLE
convert covariate error to warning

### DIFF
--- a/lib/tree.R
+++ b/lib/tree.R
@@ -81,7 +81,7 @@ read_in_metadata <- function(input, subject_identifier, label, feature_type, ran
   ## check and make sure there are not too many metadata columns
   ## we will allow 10 total columns (8 columns of additional covariates)
   if (ncol(metadata) > 10 & limit_covariates) {
-    stop("Error: You have selected too many covariates. We recommend \nthat you conduct preliminary modeling to choose the \n8 most important covariates to carry forward.")
+    warning("WARNING: You have selected quite a few covariates (this warning shows at > 8 covariates). TaxaHFE merely adds the covariates to the RF models. Its primary purpose is hierarchical feature engineering. Please do not rely on it to beautifully handle everything AND the kitchen sink.")
   }
   
   ## notify user what covariates we find, if any


### PR DESCRIPTION
This is a tiny PR, super easy to see what is going on.

The why of it: We are working on a project that will need more covariates. I guess this is a "give the user enough rope to do whatever they want" kinda of PR. 

I dont think its great...but i think in some cases it might be useful. Notice the new warning.